### PR TITLE
DDA-TAP-12: fixed compatibility issue

### DIFF
--- a/dda-tap/dda-tap.xcodeproj/project.pbxproj
+++ b/dda-tap/dda-tap.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -157,7 +157,7 @@
 				};
 			};
 			buildConfigurationList = 82196853235B97AA00036A66 /* Build configuration list for PBXProject "dda-tap" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (


### PR DESCRIPTION
Fixed compatibility issues (for Xcode 8.0-9.2):
- CompatibilityVersion is "Xcode 8.0"
- ObjectVersion is 48