### PR TITLE
DDA-TAP-35: set up TAP Guide page

### DIFF
--- a/dda-tap.xcodeproj/project.pbxproj
+++ b/dda-tap.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 				826A209C2380A365002D9081 /* MenuTable.storyboard */,
 				82765122236696B500EB39E7 /* menu.swift */,
 				828AF4B623775FED00EA789D /* Main.storyboard */,
+				BD8070672380AFC100C4E9B2 /* TAPGuide.storyboard */,
 				8276512423669FB900EB39E7 /* MenuTableViewCell.swift */,
 				E44E94B02364D7C700E784B2 /* AppDelegate.swift */,
 				824BE4BF236BF20E003AD8C1 /* TAPGuideViewController.swift */,
@@ -227,6 +228,7 @@
 				826A209D2380A365002D9081 /* MenuTable.storyboard in Resources */,
 				826A20A72380A5EC002D9081 /* Settings.storyboard in Resources */,
 				828AF4B823775FED00EA789D /* Main.storyboard in Resources */,
+				BD8070692380AFC100C4E9B2 /* TAPGuide.storyboard in Resources */,
 				E44E94BB2364D7C700E784B2 /* LaunchScreen.storyboard in Resources */,
 				E44E94B82364D7C700E784B2 /* Assets.xcassets in Resources */,
 				826A20A22380A565002D9081 /* Instructions.storyboard in Resources */,
@@ -297,6 +299,14 @@
 				828AF4B723775FED00EA789D /* Base */,
 			);
 			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		BD8070672380AFC100C4E9B2 /* TAPGuide.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				BD8070682380AFC100C4E9B2 /* Base */,
+			);
+			name = TAPGuide.storyboard;
 			sourceTree = "<group>";
 		};
 		E44E94B92364D7C700E784B2 /* LaunchScreen.storyboard */ = {

--- a/dda-tap/Base.lproj/TAPGuide~.storyboard
+++ b/dda-tap/Base.lproj/TAPGuide~.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -39,7 +39,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="57" height="63"/>
                                         <state key="normal" title="Button" image="text.justify" catalog="system"/>
                                         <connections>
-                                            <segue destination="Qbs-L6-VIH" kind="show" id="jAE-2E-6D5"/>
+                                            <segue destination="cO8-5p-4Gj" kind="show" id="jAE-2E-6D5"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h6e-EK-DFB">
@@ -290,16 +290,63 @@
             </objects>
             <point key="canvasLocation" x="900" y="-201"/>
         </scene>
-        <!--TAPGuide-->
-        <scene sceneID="iNm-Bh-XNw">
+        <!--Menu-->
+        <scene sceneID="xKK-hH-rb7">
             <objects>
-                <viewController storyboardIdentifier="UIViewController-TVL-ee-Wo0" title="TAPGuide" id="TVL-ee-Wo0" customClass="TAPGuideViewController" customModule="dda_tap" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="jEy-8j-El5">
+                <tableViewController storyboardIdentifier="menu" title="Menu" useStoryboardIdentifierAsRestorationIdentifier="YES" id="cO8-5p-4Gj" customClass="menu" customModule="dda_tap" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="Menu" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="90" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="C3s-qh-vwD">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="MenuCell" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="MenuCell" rowHeight="90" id="Amz-e1-xk4" customClass="MenuOption" customModule="dda_tap">
+                                <rect key="frame" x="0.0" y="28" width="414" height="90"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Amz-e1-xk4" id="opA-s4-3Tx">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="90"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iXU-HA-teE">
+                                            <rect key="frame" x="20" y="11" width="374" height="68"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="nameLabel" destination="iXU-HA-teE" id="rbd-3e-BAQ"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="cO8-5p-4Gj" id="p6q-W4-g4h"/>
+                            <outlet property="delegate" destination="cO8-5p-4Gj" id="2wg-QC-aUt"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" id="84R-u4-tNy"/>
+                    <value key="contentSizeForViewInPopover" type="size" width="414" height="100"/>
+                    <connections>
+                        <segue destination="Wj7-9u-pfJ" kind="show" identifier="showInstructions" id="uQU-Uf-Dma"/>
+                        <segue destination="TVL-ee-Wo0" kind="show" identifier="showTAPGuide" id="kxW-dO-pVU"/>
+                        <segue destination="r0p-QC-M8W" kind="show" identifier="showAddMainEntries" id="fwg-vt-vJe"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="7Cq-O8-P7h" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="900" y="483"/>
+        </scene>
+        <!--AddMainEntry-->
+        <scene sceneID="7L2-QX-bSi">
+            <objects>
+                <viewController title="AddMainEntry" id="r0p-QC-M8W" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="3lR-3S-SMz">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Option 3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zk0-1s-0Jv">
-                                <rect key="frame" x="186" y="438" width="67" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Option 1" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Jf-g3-wmI">
+                                <rect key="frame" x="186" y="438" width="64" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -307,6 +354,216 @@
                             </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="92q-1b-VCj"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="C90-xj-9Z4"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="xmO-fJ-rM5" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="83" y="1205"/>
+        </scene>
+        <!--Instructions-->
+        <scene sceneID="Tek-5x-BGF">
+            <objects>
+                <viewController title="Instructions" id="Wj7-9u-pfJ" customClass="InstructionsViewController" customModule="dda_tap" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="dWM-fr-vMN">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Option 2" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CP8-9g-GcO">
+                                <rect key="frame" x="186" y="438" width="66" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Pg7-bd-6Ec"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="tPU-2U-QIi"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3F0-BC-cpj" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="900" y="1205"/>
+        </scene>
+        <!--TAPGuide-->
+        <scene sceneID="iNm-Bh-XNw">
+            <objects>
+                <viewController title="TAPGuide" id="TVL-ee-Wo0" customClass="TAPGuideViewController" customModule="dda_tap" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="jEy-8j-El5">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="y2D-xG-Hya" userLabel="Guide Column Stack">
+                                <rect key="frame" x="0.0" y="118" width="414" height="597.5"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="OKX-cd-pJi" userLabel="Thumb Only">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Yy6-tT-q9V" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl autoresizesSubviews="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="fCb-8c-GQX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="E7U-Jh-k0C" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="thumb only" textAlignment="natural" lineBreakMode="tailTruncation" minimumFontSize="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="oig-xk-CUj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="j2O-Yc-QoL" userLabel="Index Only">
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="9TY-rB-fTo" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" currentPage="1" translatesAutoresizingMaskIntoConstraints="NO" id="TUd-v8-KOI">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="qUi-Fa-Tfx" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="index only" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wNs-Qo-0Mz">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="PPN-Pw-T85" userLabel="Middle Only">
+                                        <rect key="frame" x="0.0" y="199" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fwK-if-2cT" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" currentPage="2" translatesAutoresizingMaskIntoConstraints="NO" id="ONf-Vo-txz">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="sL1-fZ-mn3" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="middle only" textAlignment="natural" lineBreakMode="tailTruncation" minimumFontSize="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="zfP-La-faH">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="jSw-q0-wRs" userLabel="Index Middle">
+                                        <rect key="frame" x="0.0" y="298.5" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="vvS-Pa-ufo" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="7fZ-tK-Zaf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="E8F-R4-uir" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="index and middle" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="usR-fj-6UJ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Psk-hL-Mc9" userLabel="Middle Three">
+                                        <rect key="frame" x="0.0" y="398" width="414" height="100"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aJZ-mE-qbm" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="cSM-1T-Vup">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bt7-mf-VE3" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="100"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="middle three" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Syl-of-fhk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="0cc-aI-yc6" userLabel="All">
+                                        <rect key="frame" x="0.0" y="498" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Svz-HY-jUf" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="l6S-hp-NAj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GBh-3S-2Na" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="all" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="reu-jH-9oU">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="mtJ-hQ-2mz" firstAttribute="trailing" secondItem="y2D-xG-Hya" secondAttribute="trailing" id="3rm-WF-1DP"/>
+                            <constraint firstItem="y2D-xG-Hya" firstAttribute="top" secondItem="mtJ-hQ-2mz" secondAttribute="top" constant="30" id="Ml7-d1-d1J"/>
+                            <constraint firstAttribute="height" secondItem="y2D-xG-Hya" secondAttribute="height" multiplier="1.5" id="Xcb-RW-uUz"/>
+                            <constraint firstItem="y2D-xG-Hya" firstAttribute="leading" secondItem="mtJ-hQ-2mz" secondAttribute="leading" id="auh-aE-Aqx"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="mtJ-hQ-2mz"/>
                     </view>
                     <navigationItem key="navigationItem" id="BcN-MJ-GOd"/>
@@ -314,32 +571,6 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3FV-1p-Wch" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1752" y="1205"/>
-        </scene>
-        <!--menu-->
-        <scene sceneID="RHV-AH-Xiz">
-            <objects>
-                <viewControllerPlaceholder storyboardIdentifier="menu" storyboardName="MenuTable" referencedIdentifier="menu" id="Qbs-L6-VIH" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="rDN-jA-Gyg"/>
-                </viewControllerPlaceholder>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="gl8-69-IbQ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="900" y="483"/>
-        </scene>
-        <!--UIViewController-r0p-QC-M8W-->
-        <scene sceneID="PnG-mg-Gkq">
-            <objects>
-                <viewControllerPlaceholder storyboardIdentifier="UIViewController-r0p-QC-M8W" storyboardName="AddEntry" referencedIdentifier="UIViewController-r0p-QC-M8W" id="3tS-he-Fy1" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="hGW-0F-Lvq" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="83" y="1205"/>
-        </scene>
-        <!--UIViewController-Wj7-9u-pfJ-->
-        <scene sceneID="Ikp-P5-Juz">
-            <objects>
-                <viewControllerPlaceholder storyboardIdentifier="UIViewController-Wj7-9u-pfJ" storyboardName="Instructions'" referencedIdentifier="UIViewController-Wj7-9u-pfJ" id="z9Q-WJ-0uG" sceneMemberID="viewController"/>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="xpt-p7-mjv" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="900" y="1205"/>
         </scene>
     </scenes>
     <resources>

--- a/dda-tap/dda-tap/Base.lproj/TAPGuide.storyboard
+++ b/dda-tap/dda-tap/Base.lproj/TAPGuide.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="TVL-ee-Wo0">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15509"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,20 +9,180 @@
         <!--TAPGuide-->
         <scene sceneID="iNm-Bh-XNw">
             <objects>
-                <viewController storyboardIdentifier="UIViewController-TVL-ee-Wo0" title="TAPGuide" id="TVL-ee-Wo0" customClass="TAPGuideViewController" customModule="dda_tap" sceneMemberID="viewController">
+                <viewController title="TAPGuide" id="TVL-ee-Wo0" customClass="TAPGuideViewController" customModule="dda_tap" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="jEy-8j-El5">
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Option 3" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zk0-1s-0Jv">
-                                <rect key="frame" x="186" y="438" width="67" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="y2D-xG-Hya" userLabel="Guide Column Stack">
+                                <rect key="frame" x="0.0" y="118" width="414" height="597.5"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="OKX-cd-pJi" userLabel="Thumb Only">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Yy6-tT-q9V" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl autoresizesSubviews="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="fCb-8c-GQX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="E7U-Jh-k0C" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="thumb only" textAlignment="natural" lineBreakMode="tailTruncation" minimumFontSize="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="oig-xk-CUj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="j2O-Yc-QoL" userLabel="Index Only">
+                                        <rect key="frame" x="0.0" y="99.5" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="9TY-rB-fTo" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" currentPage="1" translatesAutoresizingMaskIntoConstraints="NO" id="TUd-v8-KOI">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="qUi-Fa-Tfx" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="index only" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="wNs-Qo-0Mz">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="PPN-Pw-T85" userLabel="Middle Only">
+                                        <rect key="frame" x="0.0" y="199" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="fwK-if-2cT" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" currentPage="2" translatesAutoresizingMaskIntoConstraints="NO" id="ONf-Vo-txz">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="sL1-fZ-mn3" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="middle only" textAlignment="natural" lineBreakMode="tailTruncation" minimumFontSize="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="zfP-La-faH">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="jSw-q0-wRs" userLabel="Index Middle">
+                                        <rect key="frame" x="0.0" y="298.5" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="vvS-Pa-ufo" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="7fZ-tK-Zaf">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="E8F-R4-uir" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="index and middle" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="usR-fj-6UJ">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Psk-hL-Mc9" userLabel="Middle Three">
+                                        <rect key="frame" x="0.0" y="398" width="414" height="100"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="aJZ-mE-qbm" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="cSM-1T-Vup">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="bt7-mf-VE3" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="100"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="middle three" textAlignment="natural" lineBreakMode="tailTruncation" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="Syl-of-fhk">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="100"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="0cc-aI-yc6" userLabel="All">
+                                        <rect key="frame" x="0.0" y="498" width="414" height="99.5"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Svz-HY-jUf" userLabel="Gesture Stack">
+                                                <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="5" translatesAutoresizingMaskIntoConstraints="NO" id="l6S-hp-NAj">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <color key="pageIndicatorTintColor" systemColor="placeholderTextColor" red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.29999999999999999" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <color key="currentPageIndicatorTintColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    </pageControl>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GBh-3S-2Na" userLabel="Label Stack">
+                                                <rect key="frame" x="207" y="0.0" width="207" height="99.5"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="all" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="reu-jH-9oU">
+                                                        <rect key="frame" x="0.0" y="0.0" width="207" height="99.5"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                            </stackView>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="mtJ-hQ-2mz" firstAttribute="trailing" secondItem="y2D-xG-Hya" secondAttribute="trailing" id="3rm-WF-1DP"/>
+                            <constraint firstItem="y2D-xG-Hya" firstAttribute="top" secondItem="mtJ-hQ-2mz" secondAttribute="top" constant="30" id="Ml7-d1-d1J"/>
+                            <constraint firstAttribute="height" secondItem="y2D-xG-Hya" secondAttribute="height" multiplier="1.5" id="Xcb-RW-uUz"/>
+                            <constraint firstItem="y2D-xG-Hya" firstAttribute="leading" secondItem="mtJ-hQ-2mz" secondAttribute="leading" id="auh-aE-Aqx"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="mtJ-hQ-2mz"/>
                     </view>
                     <navigationItem key="navigationItem" id="BcN-MJ-GOd"/>


### PR DESCRIPTION
-Added gestures and labels according to the drive document
-PageControl is used as a temporary placeholder for gesture diagrams
-May need to change the set up of this page to allow dynamic addition of guide entries if user wishes to modify/add/remove gesture guide entries on their own