### PR TITLE
DDA-TAP-62A: Saving state on Settings page (Text/Switches)

### DIFF
--- a/dda-tap.xcodeproj/project.pbxproj
+++ b/dda-tap.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		5DA7733A23E556A9002288DA /* AddEntryUnitTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA7733923E556A9002288DA /* AddEntryUnitTest.swift */; };
+		5DF384C4241448A2001326DE /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF384C3241448A1001326DE /* SettingsViewController.swift */; };
 		5DF5DEC82380AB42002450C1 /* AddEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DF5DEC72380AB42002450C1 /* AddEntryViewController.swift */; };
 		824BE4BE236BF1B0003AD8C1 /* InstructionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BE4BD236BF1B0003AD8C1 /* InstructionsViewController.swift */; };
 		824BE4C0236BF20E003AD8C1 /* TAPGuideViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 824BE4BF236BF20E003AD8C1 /* TAPGuideViewController.swift */; };
@@ -51,6 +52,7 @@
 
 /* Begin PBXFileReference section */
 		5DA7733923E556A9002288DA /* AddEntryUnitTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddEntryUnitTest.swift; sourceTree = "<group>"; };
+		5DF384C3241448A1001326DE /* SettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		5DF5DEC72380AB42002450C1 /* AddEntryViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddEntryViewController.swift; sourceTree = "<group>"; };
 		824BE4BD236BF1B0003AD8C1 /* InstructionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstructionsViewController.swift; sourceTree = "<group>"; };
 		824BE4BF236BF20E003AD8C1 /* TAPGuideViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TAPGuideViewController.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 		E44E94AF2364D7C700E784B2 /* dda-tap */ = {
 			isa = PBXGroup;
 			children = (
+				5DF384C3241448A1001326DE /* SettingsViewController.swift */,
 				CA9D1E762389DD8E0029A0CF /* imagePageViewController copy.swift */,
 				826A20A32380A5C6002D9081 /* TAPGuide.storyboard */,
 				5DF5DEC72380AB42002450C1 /* AddEntryViewController.swift */,
@@ -261,6 +264,7 @@
 				8276512523669FB900EB39E7 /* MenuTableViewCell.swift in Sources */,
 				824BE4C0236BF20E003AD8C1 /* TAPGuideViewController.swift in Sources */,
 				CA9D1E772389DD8E0029A0CF /* imagePageViewController copy.swift in Sources */,
+				5DF384C4241448A2001326DE /* SettingsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dda-tap/Settings.storyboard
+++ b/dda-tap/Settings.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CAw-dy-dv1">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CAw-dy-dv1">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +20,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="yGl-Ai-22E">
-                                <rect key="frame" x="15" y="30" width="345" height="582"/>
+                                <rect key="frame" x="15" y="50" width="345" height="562"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dh0-0W-fcx">
                                         <rect key="frame" x="0.0" y="0.0" width="200" height="40"/>
@@ -33,7 +35,7 @@
                                                 <rect key="frame" x="0.0" y="17.5" width="167.5" height="74"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="VolumeIcon" translatesAutoresizingMaskIntoConstraints="NO" id="XwK-He-tzT">
-                                                        <rect key="frame" x="0.0" y="0.0" width="167.50000000000003" height="74"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="167.5" height="74"/>
                                                     </imageView>
                                                 </subviews>
                                             </stackView>
@@ -54,26 +56,29 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="kpy-vN-dLW">
-                                        <rect key="frame" x="0.0" y="279" width="345" height="303"/>
+                                        <rect key="frame" x="0.0" y="279" width="345" height="283"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Oge-VC-jQN">
-                                                <rect key="frame" x="0.0" y="0.0" width="345" height="36.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="345" height="32.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Tim-YD-mbQ">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="36.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="32.5"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen2" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MEK-Gv-RZg">
-                                                                <rect key="frame" x="43.5" y="0.0" width="82" height="36.5"/>
+                                                                <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="8Y6-zV-dHz">
-                                                        <rect key="frame" x="176.5" y="3" width="168.5" height="31"/>
+                                                        <rect key="frame" x="176.5" y="1" width="168.5" height="31"/>
                                                         <subviews>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QuQ-qt-SWn">
                                                                 <rect key="frame" x="60" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="toggleSwitch1:" destination="CAw-dy-dv1" eventType="valueChanged" id="2jp-B6-ATY"/>
+                                                                </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
@@ -83,23 +88,26 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="ZYQ-Va-uWR">
-                                                <rect key="frame" x="0.0" y="66.5" width="345" height="36.5"/>
+                                                <rect key="frame" x="0.0" y="62.5" width="345" height="32.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="N9w-JB-ozS">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="36.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="32.5"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen3" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="z8T-Uq-DD1">
-                                                                <rect key="frame" x="43.5" y="0.0" width="82" height="36.5"/>
+                                                                <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="dH6-2p-hZb">
-                                                        <rect key="frame" x="176.5" y="3" width="168.5" height="31"/>
+                                                        <rect key="frame" x="176.5" y="1" width="168.5" height="31"/>
                                                         <subviews>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WHl-mv-KZG">
                                                                 <rect key="frame" x="60" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="toggleSwitch2:" destination="CAw-dy-dv1" eventType="valueChanged" id="8Qi-Ri-Xdm"/>
+                                                                </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
@@ -109,23 +117,26 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="fT9-tn-TjJ">
-                                                <rect key="frame" x="0.0" y="133" width="345" height="37"/>
+                                                <rect key="frame" x="0.0" y="125" width="345" height="33"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="fuj-a1-aci">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="37"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="33"/>
                                                         <subviews>
-                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen4" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PRQ-UE-Cg2">
-                                                                <rect key="frame" x="43" y="0.0" width="83" height="37"/>
+                                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen4" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PRQ-UE-Cg2" userLabel="Text3">
+                                                                <rect key="frame" x="46.5" y="0.0" width="76" height="33"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="tFK-yh-oPv">
-                                                        <rect key="frame" x="176.5" y="3" width="168.5" height="31"/>
+                                                        <rect key="frame" x="176.5" y="1" width="168.5" height="31"/>
                                                         <subviews>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5IJ-uF-nYs">
                                                                 <rect key="frame" x="60" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="toggleSwitch3:" destination="CAw-dy-dv1" eventType="valueChanged" id="Afp-nM-q8b"/>
+                                                                </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
@@ -135,23 +146,26 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="baP-d5-5CN">
-                                                <rect key="frame" x="0.0" y="200" width="345" height="36.5"/>
+                                                <rect key="frame" x="0.0" y="188" width="345" height="32.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Bsy-tG-Ae6">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="36.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="32.5"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen5" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PNS-DQ-RQZ">
-                                                                <rect key="frame" x="43.5" y="0.0" width="82" height="36.5"/>
+                                                                <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="6uI-7a-OWj">
-                                                        <rect key="frame" x="176.5" y="2.5" width="168.5" height="31"/>
+                                                        <rect key="frame" x="176.5" y="0.5" width="168.5" height="31"/>
                                                         <subviews>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cX1-gE-WCX">
                                                                 <rect key="frame" x="60" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="toggleSwitch4:" destination="CAw-dy-dv1" eventType="valueChanged" id="RB4-J4-blN"/>
+                                                                </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
@@ -161,23 +175,26 @@
                                                 </constraints>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="Fbj-R4-vId">
-                                                <rect key="frame" x="0.0" y="266.5" width="345" height="36.5"/>
+                                                <rect key="frame" x="0.0" y="250.5" width="345" height="32.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="nlq-o6-GyD">
-                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="36.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="168.5" height="32.5"/>
                                                         <subviews>
                                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="Screen6" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Che-tU-GRb">
-                                                                <rect key="frame" x="43.5" y="0.0" width="82" height="36.5"/>
+                                                                <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="k9z-Xh-lrW">
-                                                        <rect key="frame" x="176.5" y="2.5" width="168.5" height="31"/>
+                                                        <rect key="frame" x="176.5" y="0.5" width="168.5" height="31"/>
                                                         <subviews>
                                                             <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4bR-uE-dkR">
                                                                 <rect key="frame" x="60" y="0.0" width="51" height="31"/>
+                                                                <connections>
+                                                                    <action selector="toggleSwitch5:" destination="CAw-dy-dv1" eventType="valueChanged" id="NhJ-v9-5rc"/>
+                                                                </connections>
                                                             </switch>
                                                         </subviews>
                                                     </stackView>
@@ -208,6 +225,13 @@
                         <viewLayoutGuide key="safeArea" id="TPJ-QN-8O7"/>
                     </view>
                     <navigationItem key="navigationItem" id="GOp-Wq-d6c"/>
+                    <connections>
+                        <outlet property="switch1" destination="QuQ-qt-SWn" id="0BI-L7-NQV"/>
+                        <outlet property="switch2" destination="WHl-mv-KZG" id="pNr-U1-Imj"/>
+                        <outlet property="switch3" destination="5IJ-uF-nYs" id="S5c-JA-dUp"/>
+                        <outlet property="switch4" destination="cX1-gE-WCX" id="Gnl-2z-uuy"/>
+                        <outlet property="switch5" destination="4bR-uE-dkR" id="4ry-gc-0v0"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ys9-8d-lGg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/dda-tap/Settings.storyboard
+++ b/dda-tap/Settings.storyboard
@@ -68,6 +68,9 @@
                                                                 <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
+                                                                <connections>
+                                                                    <action selector="onTextField1Changed:" destination="CAw-dy-dv1" eventType="editingDidEnd" id="3DP-xs-mM8"/>
+                                                                </connections>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -97,6 +100,9 @@
                                                                 <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
+                                                                <connections>
+                                                                    <action selector="onTextField2Changed:" destination="CAw-dy-dv1" eventType="editingDidEnd" id="sqi-5M-dv9"/>
+                                                                </connections>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -126,6 +132,9 @@
                                                                 <rect key="frame" x="46.5" y="0.0" width="76" height="33"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
+                                                                <connections>
+                                                                    <action selector="onTextField3Changed:" destination="CAw-dy-dv1" eventType="editingDidEnd" id="Qwz-Nx-DE5"/>
+                                                                </connections>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -155,6 +164,9 @@
                                                                 <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
+                                                                <connections>
+                                                                    <action selector="onTextField4Changed:" destination="CAw-dy-dv1" eventType="editingDidEnd" id="eOU-4i-5Uk"/>
+                                                                </connections>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -184,6 +196,9 @@
                                                                 <rect key="frame" x="47" y="0.0" width="75" height="32.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
+                                                                <connections>
+                                                                    <action selector="onTextField5Changed:" destination="CAw-dy-dv1" eventType="editingDidEnd" id="LGB-73-jKf"/>
+                                                                </connections>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -231,6 +246,11 @@
                         <outlet property="switch3" destination="5IJ-uF-nYs" id="S5c-JA-dUp"/>
                         <outlet property="switch4" destination="cX1-gE-WCX" id="Gnl-2z-uuy"/>
                         <outlet property="switch5" destination="4bR-uE-dkR" id="4ry-gc-0v0"/>
+                        <outlet property="textField1" destination="MEK-Gv-RZg" id="m9w-cs-5Zs"/>
+                        <outlet property="textField2" destination="z8T-Uq-DD1" id="Yz7-Wt-Y9D"/>
+                        <outlet property="textField3" destination="PRQ-UE-Cg2" id="fvw-TD-GBO"/>
+                        <outlet property="textField4" destination="PNS-DQ-RQZ" id="Eve-AF-cTV"/>
+                        <outlet property="textField5" destination="Che-tU-GRb" id="vZ7-yb-Zf2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ys9-8d-lGg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/dda-tap/SettingsViewController.swift
+++ b/dda-tap/SettingsViewController.swift
@@ -16,24 +16,49 @@ class SettingsViewController: UIViewController {
         super.viewDidLoad()
     
         // Do any additional setup after loading the view.
-        switch1.isOn = userDefaults.bool(forKey: "switch1")
-        switch2.isOn = userDefaults.bool(forKey: "switch2")
-        switch3.isOn = userDefaults.bool(forKey: "switch3")
-        switch4.isOn = userDefaults.bool(forKey: "switch4")
-        switch5.isOn = userDefaults.bool(forKey: "switch5") 
+        handleFirstLoadIfNeeded()
+        loadSwitchesAndTextFields()
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        switch1.isOn = userDefaults.bool(forKey: "switch1")
-        switch2.isOn = userDefaults.bool(forKey: "switch2")
-        switch3.isOn = userDefaults.bool(forKey: "switch3")
-        switch4.isOn = userDefaults.bool(forKey: "switch4")
-        switch5.isOn = userDefaults.bool(forKey: "switch5")
+        
+        loadSwitchesAndTextFields()
     }
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
+    }
+    
+    func handleFirstLoadIfNeeded() {
+        if (userDefaults.object(forKey: "switch1") == nil) {
+            userDefaults.set(true, forKey:"switch1")
+            userDefaults.set(true, forKey:"switch2")
+            userDefaults.set(true, forKey:"switch3")
+            userDefaults.set(true, forKey:"switch4")
+            userDefaults.set(true, forKey:"switch5")
+        }
+        if (userDefaults.object(forKey: "textField1") == nil) {
+            userDefaults.set("Screen1", forKey: "textField1")
+            userDefaults.set("Screen2", forKey: "textField2")
+            userDefaults.set("Screen3", forKey: "textField3")
+            userDefaults.set("Screen4", forKey: "textField4")
+            userDefaults.set("Screen5", forKey: "textField5")
+        }
+    }
+    
+    func loadSwitchesAndTextFields() {
+        switch1.isOn = userDefaults.bool(forKey: "switch1")
+        switch2.isOn = userDefaults.bool(forKey: "switch2")
+        switch3.isOn = userDefaults.bool(forKey: "switch3")
+        switch4.isOn = userDefaults.bool(forKey: "switch4")
+        switch5.isOn = userDefaults.bool(forKey: "switch5")
+        
+        textField1.text = userDefaults.string(forKey: "textField1")
+        textField2.text = userDefaults.string(forKey: "textField2")
+        textField3.text = userDefaults.string(forKey: "textField3")
+        textField4.text = userDefaults.string(forKey: "textField4")
+        textField5.text = userDefaults.string(forKey: "textField5")
     }
     
     
@@ -47,6 +72,7 @@ class SettingsViewController: UIViewController {
     @IBAction func toggleSwitch1(_ sender: UISwitch) {
         userDefaults.set(sender.isOn, forKey: "switch1")
     }
+    
     
     @IBAction func toggleSwitch2(_ sender: UISwitch) {
         userDefaults.set(sender.isOn, forKey: "switch2")
@@ -63,11 +89,37 @@ class SettingsViewController: UIViewController {
     }
     
     
-
     @IBAction func toggleSwitch5(_ sender: UISwitch) {
         userDefaults.set(sender.isOn, forKey: "switch5")
     }
     
+    
+    @IBOutlet weak var textField1: UITextField!
+    @IBOutlet weak var textField2: UITextField!
+    @IBOutlet weak var textField3: UITextField!
+    @IBOutlet weak var textField4: UITextField!
+    @IBOutlet weak var textField5: UITextField!
+    
+    
+    @IBAction func onTextField1Changed(_ sender: UITextField) {
+        userDefaults.set(sender.text, forKey: "textField1")
+    }
+    
+    @IBAction func onTextField2Changed(_ sender: UITextField) {
+        userDefaults.set(sender.text, forKey: "textField2")
+    }
+    
+    @IBAction func onTextField3Changed(_ sender: UITextField) {
+        userDefaults.set(sender.text, forKey: "textField3")
+    }
+    
+    @IBAction func onTextField4Changed(_ sender: UITextField) {
+        userDefaults.set(sender.text, forKey: "textField4")
+    }
+    
+    @IBAction func onTextField5Changed(_ sender: UITextField) {
+        userDefaults.set(sender.text, forKey: "textField5")
+    }
     
     /*
     // MARK: - Navigation

--- a/dda-tap/SettingsViewController.swift
+++ b/dda-tap/SettingsViewController.swift
@@ -9,11 +9,26 @@
 import UIKit
 
 class SettingsViewController: UIViewController {
-
+    
+    var userDefaults = UserDefaults.standard
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
+    
         // Do any additional setup after loading the view.
+        switch1.isOn = userDefaults.bool(forKey: "switch1")
+        switch2.isOn = userDefaults.bool(forKey: "switch2")
+        switch3.isOn = userDefaults.bool(forKey: "switch3")
+        switch4.isOn = userDefaults.bool(forKey: "switch4")
+        switch5.isOn = userDefaults.bool(forKey: "switch5") 
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        switch1.isOn = userDefaults.bool(forKey: "switch1")
+        switch2.isOn = userDefaults.bool(forKey: "switch2")
+        switch3.isOn = userDefaults.bool(forKey: "switch3")
+        switch4.isOn = userDefaults.bool(forKey: "switch4")
+        switch5.isOn = userDefaults.bool(forKey: "switch5")
     }
 
     override func didReceiveMemoryWarning() {
@@ -21,7 +36,39 @@ class SettingsViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    
+    @IBOutlet weak var switch1: UISwitch!
+    @IBOutlet weak var switch2: UISwitch!
+    @IBOutlet weak var switch3: UISwitch!
+    @IBOutlet weak var switch4: UISwitch!
+    @IBOutlet weak var switch5: UISwitch!
+    
+    
+    @IBAction func toggleSwitch1(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: "switch1")
+    }
+    
+    @IBAction func toggleSwitch2(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: "switch2")
+    }
+    
+    
+    @IBAction func toggleSwitch3(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: "switch3")
+    }
+    
+    
+    @IBAction func toggleSwitch4(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: "switch4")
+    }
+    
+    
 
+    @IBAction func toggleSwitch5(_ sender: UISwitch) {
+        userDefaults.set(sender.isOn, forKey: "switch5")
+    }
+    
+    
     /*
     // MARK: - Navigation
 
@@ -31,5 +78,4 @@ class SettingsViewController: UIViewController {
         // Pass the selected object to the new view controller.
     }
     */
-
 }


### PR DESCRIPTION
Now have:
- Buttons saving state
- TextFields saving state
- If not previously set, TextFields initialize to "Screen1", "Screen2", etc.
- If not previously set, Buttons initialize to ON